### PR TITLE
Updated README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,9 @@ If I forgot something just create a Pull Request with the stuff added and I will
 
 # List of contributers to the document :D
 
-PrincessAkira Owner, created this page  
-MGThePro Cleaned up some stuff, fixed typos and links
-Mou-Ikkai Fixed a gif
-Descent098 Helped clarify the settings to use for the key
-sanikdah Cleaned up some images, typos, and wrote this section and the uninstall updates section
-pajamaclaws21 
+[https://github.com/PrincessAkira](PrincessAkira) Owner, created this page<br>
+[https://github.com/MGThePro](MGThePro) Cleaned up some stuff, fixed typos and links<br>
+Mou-Ikkai Fixed a gif<br>
+[https://github.com/Descent098](Descent098) Helped clarify the settings to use for the key<br>
+sanikdah Cleaned up some images, typos, and wrote this section and the uninstall updates section<br>
+[https://github.com/pajamaclaws21](pajamaclaws21)

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ It's pretty simple, as an example, we're gonna take the mod from [here](https://
 
 There are multiple sites to get Mods altogether.
 
--  https://drive.google.com/drive/folders/1dY20qH3phqoUfmAEdngTzrtMIvPFwSG4?usp=sharing
+-  [Mods saved on Google Drive](https://drive.google.com/drive/folders/1dY20qH3phqoUfmAEdngTzrtMIvPFwSG4?usp=sharing)
 -  [switch-ptchtxt-mods](https://github.com/theboy181/switch-ptchtxt-mods)
 -  [Switch-Mods](https://github.com/yuzu-emu/yuzu/wiki/Switch-Mods)
 

--- a/README.md
+++ b/README.md
@@ -133,9 +133,9 @@ If I forgot something just create a Pull Request with the stuff added and I will
 
 # List of contributers to the document :D
 
-[https://github.com/PrincessAkira](PrincessAkira) Owner, created this page<br>
-[https://github.com/MGThePro](MGThePro) Cleaned up some stuff, fixed typos and links<br>
+[PrincessAkira](https://github.com/PrincessAkira) Owner, created this page<br>
+[MGThePro](https://github.com/MGThePro) Cleaned up some stuff, fixed typos and links<br>
 Mou-Ikkai Fixed a gif<br>
-[https://github.com/Descent098](Descent098) Helped clarify the settings to use for the key<br>
+[Descent098](https://github.com/Descent098) Helped clarify the settings to use for the key<br>
 sanikdah Cleaned up some images, typos, and wrote this section and the uninstall updates section<br>
-[https://github.com/pajamaclaws21](pajamaclaws21)
+[pajamaclaws21](https://github.com/pajamaclaws21)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Then press on `Add` and make a new profile, then close Yuzu.
 
 Inside of Yuzu, click `File -> Open Yuzu folder`. This will open the Yuzu configuration folder inside of explorer.
 
-Create a folder called "keys" and copy the keyfile you got from [Reddit](https://www.reddit.com/r/NewYuzuPiracy/) or anywhere else in there. A viable place to get keys is [128 Bit Bay](https://rentry.org/128bbkeys).
+Create a folder called "keys" and copy the keyfile you got from [128 Bit Bay](https://rentry.org/128bbkeys).
 
 Note: The File name should be prod.keys, not prod.keys.txt.
 
@@ -119,8 +119,8 @@ It's pretty simple, as an example, we're gonna take the mod from [here](https://
 There are multiple sites to get Mods altogether.
 
 -  https://drive.google.com/drive/folders/1dY20qH3phqoUfmAEdngTzrtMIvPFwSG4?usp=sharing
--  https://github.com/theboy181/switch-ptchtxt-mods
--  https://github.com/yuzu-emu/yuzu/wiki/Switch-Mods
+-  [switch-ptchtxt-mods](https://github.com/theboy181/switch-ptchtxt-mods)
+-  [Switch-Mods](https://github.com/yuzu-emu/yuzu/wiki/Switch-Mods)
 
 -  Additional Note here:
    If you got any other names for the folder don't rename it to exefs.


### PR DESCRIPTION
- Removed reference to [NewYuzuPiracy](https://www.reddit.com/r/NewYuzuPiracy/) due to the reason the subreddit was banned from Reddit.
- Changed "switch-ptchtxt-mods", "Switch-Mods" and the "Google Drive" links to clickable hyperlinks
- Created hyperlinks to the profiles of the users that were named in the list of contributers. Two Github accounts couldn't be found and so their username is listed without a hyperlink

~~By the time of creating this PR, it was unable to access [128 Bit Bay](https://rentry.org/128bbkeys) this should be looked at if in the future it still won't be accessible, so this can be replaced by a different source for the user.~~

Also ADHD energy is kicking different because I am doing this right now at 02:38am.